### PR TITLE
Implement interactive practice workflow

### DIFF
--- a/bobby/style.css
+++ b/bobby/style.css
@@ -1,2 +1,7 @@
 .bold { font-weight: bold; }
 .dim-label { color: #336699; font-size: small; }
+.playing { color: #0066cc; }
+.recording { color: #cc0000; }
+.analyzing { color: #cc6600; }
+.result-good { color: #009933; }
+.result-bad { color: #cc0000; }


### PR DESCRIPTION
## Summary
- add threaded practice workflow that plays, records, analyzes and shows feedback
- add visual state cues for playback, recording and analysis
- highlight results in the row
- show helpful dialog when bottom "Practice" button is pressed
- update CSS with state classes

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_683cbea333ac832eb3a055ed3ad395c5